### PR TITLE
chore(ci): pin external workflow actions

### DIFF
--- a/.github/workflows/check_pr_title_style.yml
+++ b/.github/workflows/check_pr_title_style.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017  # Using 5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: npm clean-install
 
-      - uses: codfish/semantic-release-action@v3
+      - uses: codfish/semantic-release-action@b621d34fabe0940f031e89b6ebfea28322892a10  # Using 3.5.0
         id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This PR updates GitHub Actions workflows to:

1. Pin external actions to specific commit hashes for better security and reproducibility

**Files changed:**
- .github/workflows/check_pr_title_style.yml
- .github/workflows/release_package.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI workflows updated to pin third-party actions to specific, vetted revisions to improve build reliability and supply‑chain security.
  - Pinning applied to workflows for PR title validation and release automation to ensure consistent, reproducible runs.
  - No changes to product features, UI, or user-facing behavior; infrastructure-only updates that won't affect day-to-day usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->