### PR TITLE
ci(build): potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_lint_test.yml
+++ b/.github/workflows/build_lint_test.yml
@@ -1,4 +1,6 @@
 name: Build, Lint, Test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/akadenia/AkadeniaLogger/security/code-scanning/1](https://github.com/akadenia/AkadeniaLogger/security/code-scanning/1)

To fix this problem, we should add a `permissions` block to limit the `GITHUB_TOKEN`'s permissions. Since this workflow only builds, lints, and tests code, the job only needs to check out source code and does not need write permissions to the repository, issues, or pull requests. The best way to fix this is to add `permissions: contents: read` either at the top level of the workflow (making it apply to all jobs), or specifically under the job in question. This addresses least privilege and makes the workflow secure against privilege escalation. The best practice would be to set the block at the top of the file, right after the workflow name, before `on:`. No extra imports or structural changes are needed—just the addition of the permissions block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->