### PR TITLE
ci(circleci): add circleci build, test, and release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@6.1
+
+jobs:
+  build-lint-test:
+    docker:
+      - image: cimg/node:22.14
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: npm
+      - run: npm run build
+      - run: npm run lint
+      - run: npm run test
+
+  release:
+    docker:
+      - image: cimg/node:22.14
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: npm
+      - run: npm run build
+      - run: npx semantic-release
+
+workflows:
+  build-lint-test-and-release:
+    jobs:
+      - build-lint-test
+      - release:
+          requires:
+            - build-lint-test
+          filters:
+            branches:
+              only: main


### PR DESCRIPTION
Adds CircleCI configuration that replicates the existing GitHub Actions CI/CD pipeline:

- **build-lint-test** job: runs on all branches — checkout, npm ci (cached), build, lint, test
- **release** job: runs on main only after build-lint-test passes — runs semantic-release

Uses CircleCI 2.1 with the `circleci/node` orb for dependency caching. Expects `NPM_TOKEN` and `GH_TOKEN` to be configured in CircleCI project settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated continuous integration and release workflow to enable consistent code quality checks and streamlined deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->