### PR TITLE
fix(ci): allow uppercase in PR title subject and remove write permissions

### DIFF
--- a/.github/workflows/check_pr_title_style.yml
+++ b/.github/workflows/check_pr_title_style.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
-      statuses: write
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # Using 5.5.3
         env:
@@ -27,15 +26,15 @@ jobs:
           disallowScopes: |
             core
           # Configure additional validation for the subject based on a regex.
-          # This example ensures the subject doesn't start with an uppercase character.
-          subjectPattern: ^(?![A-Z])[A-Za-z0-9\s!@#$%^&*()-_+=|{}\[\]:;"'<>,.?/~`]+$
+          # This example ensures the subject must only contain valid characters.
+          subjectPattern: ^[A-Za-z0-9\s!@#$%^&*()-_+=|{}\[\]:;"'<>,.?/~`]+$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
-            doesn't start with an uppercase character.
+            must only contain valid characters.
           ignoreLabels: |
             bot
             ignore-semantic-pull-request


### PR DESCRIPTION
## Changes

- Allow uppercase letters in PR title subjects (removed negative lookahead from subjectPattern)
- Removed statuses: write permission — workflow only needs read access
- Updated error message

Fixes PR title check failures on CircleCI migration PRs.