### PR TITLE
ci(pr-check): replace third-party action with custom PR title validator

### DIFF
--- a/.github/workflows/check_pr_title_style.yml
+++ b/.github/workflows/check_pr_title_style.yml
@@ -63,10 +63,9 @@ jobs:
             exit 1
           fi
 
-          # Validate subject characters
-          SUBJECT_PATTERN='^[A-Za-z0-9 !@#$%^&*()_+=|{}\[\]:;"'\''<>,.?/~`-]+$'
-          if [[ ! "$SUBJECT" =~ $SUBJECT_PATTERN ]]; then
-            echo "❌ Subject contains invalid characters: '$SUBJECT'"
+          # Validate subject is not empty
+          if [[ -z "$SUBJECT" || "$SUBJECT" =~ ^[[:space:]]+$ ]]; then
+            echo "❌ Subject cannot be empty"
             exit 1
           fi
 


### PR DESCRIPTION
## Short Summary
Replaces `amannn/action-semantic-pull-request` with a simple bash-based validator. The third-party action requires `pull-requests: read` permission which fails for bot/integration users ('Resource not accessible by integration').

Our custom script reads the title directly from the event payload — no API calls, no token needed.

**Rules preserved:**
- Conventional commit format: `type(scope): subject`
- Scope required, `core` scope disallowed
- `[WIP]` prefix skips validation
- `bot` / `ignore-semantic-pull-request` labels skip validation
- Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert

## Screenshots
N/A — CI configuration only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked PR title validation: replaced the external validator with an inline Bash-based check in the CI workflow. Validation now conditionally skips WIP/ignored labels, enforces type, scope and subject rules, disallows the 'core' scope, and provides clear success or error messages. Removed reliance on the external action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->