### PR TITLE
ci(release): add semantic-release GitHub Actions workflow

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,28 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": true
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "npm run build"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@jest/globals": "^30.3.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
         "@types/node": "^24.12.0",
         "jest": "^30.3.0",
         "prettier": "^3.3.3",
@@ -1759,6 +1760,39 @@
       },
       "peerDependencies": {
         "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/git": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
+      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.0",
+        "p-reduce": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/p-reduce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@semantic-release/github": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "prettier": "^3.3.3",
     "semantic-release": "22.0.12",
     "ts-jest": "^29.4.5",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "@semantic-release/git": "^10.0.1"
   },
   "dependencies": {
     "@akadenia/api": "^1.2.0",


### PR DESCRIPTION
## What
- Add `release.yml` GitHub Actions workflow (build, lint, test, publish on push to main)
- Add `.releaserc.json` with changelog, npm, git, and GitHub release plugins
- Add `@semantic-release/git` to devDependencies

## Why
Automates npm publishing on merge to main via semantic-release. No more manual `npm publish`.

## How it works
1. Push/merge to `main` triggers the workflow
2. semantic-release analyzes commit messages (conventional commits)
3. Bumps version, updates CHANGELOG.md, publishes to npm, creates GitHub release