### PR TITLE
chore(deps): drop @akadenia/api dependency

### DIFF
--- a/__tests__/signoz_adapter.test.ts
+++ b/__tests__/signoz_adapter.test.ts
@@ -2,6 +2,8 @@ import { jest, describe, expect, it, beforeEach, afterEach } from "@jest/globals
 import { SignozAdapter, SignozSeverity } from "../src/adapters/signoz_adapter"
 import { Severity } from "../src/logger"
 
+const originalFetch = global.fetch
+
 function mockFetchOk() {
   global.fetch = jest.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 200 }))
 }
@@ -24,6 +26,7 @@ describe("SignozAdapter Tests", () => {
 
   afterEach(() => {
     jest.clearAllMocks()
+    global.fetch = originalFetch
   })
 
   describe("Constructor", () => {
@@ -516,6 +519,36 @@ describe("SignozAdapter Tests", () => {
       const result = await (signozAdapter as any).captureMessage("Test", SignozSeverity.Info)
 
       expect(result).toBe(true)
+    })
+
+    it("should return false when fetch throws", async () => {
+      global.fetch = jest.fn<typeof fetch>().mockRejectedValue(new Error("Network failure"))
+
+      const result = await (signozAdapter as any).captureMessage("Test", SignozSeverity.Info)
+
+      expect(result).toBe(false)
+      expect(console.debug).toHaveBeenCalledWith("SignozAdapter fetch error:", expect.any(Error))
+    })
+
+    it("should return false and log timeout when fetch is aborted", async () => {
+      jest.useFakeTimers()
+      global.fetch = jest.fn<typeof fetch>().mockImplementation((_url, init) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            const err = new Error("The operation was aborted")
+            err.name = "AbortError"
+            reject(err)
+          })
+        })
+      })
+
+      const capturePromise = (signozAdapter as any).captureMessage("Test", SignozSeverity.Info)
+      jest.advanceTimersByTime(6000)
+      const result = await capturePromise
+
+      expect(result).toBe(false)
+      expect(console.debug).toHaveBeenCalledWith("SignozAdapter fetch timeout")
+      jest.useRealTimers()
     })
   })
 })

--- a/__tests__/signoz_adapter.test.ts
+++ b/__tests__/signoz_adapter.test.ts
@@ -1,27 +1,25 @@
 import { jest, describe, expect, it, beforeEach, afterEach } from "@jest/globals"
 import { SignozAdapter, SignozSeverity } from "../src/adapters/signoz_adapter"
 import { Severity } from "../src/logger"
-import { AxiosApiClient, AkadeniaApiResponse } from "@akadenia/api"
 
-jest.mock("@akadenia/api", () => ({
-  AxiosApiClient: jest.fn(),
-}))
+function mockFetchOk() {
+  global.fetch = jest.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 200 }))
+}
+
+function mockFetchError(statusText: string, body: string) {
+  global.fetch = jest.fn<typeof fetch>().mockResolvedValue(new Response(body, { status: 500, statusText }))
+}
+
+function lastFetchBody(): any {
+  const calls = (global.fetch as jest.Mock).mock.calls
+  return JSON.parse((calls[calls.length - 1] as any)[1].body)
+}
 
 describe("SignozAdapter Tests", () => {
-  let mockApiClient: any
   let signozAdapter: SignozAdapter
 
   beforeEach(() => {
-    mockApiClient = {
-      post: (jest.fn() as any).mockResolvedValue({
-        success: true,
-        message: "Success",
-        data: {},
-      }),
-    }
-    ;(AxiosApiClient as jest.MockedClass<typeof AxiosApiClient>).mockImplementation(() => {
-      return mockApiClient as any
-    })
+    mockFetchOk()
   })
 
   afterEach(() => {
@@ -35,12 +33,6 @@ describe("SignozAdapter Tests", () => {
       expect(signozAdapter.name).toBe("signoz")
       expect(signozAdapter.minimumLogLevel).toBe(Severity.Debug)
       expect(signozAdapter.url.toString()).toBe("http://collector:4318/v1/logs")
-      expect(AxiosApiClient).toHaveBeenCalledWith({
-        baseUrl: "http://collector:4318/v1/logs",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
     })
 
     it("should accept a URL object", () => {
@@ -48,24 +40,12 @@ describe("SignozAdapter Tests", () => {
       signozAdapter = new SignozAdapter(url, Severity.Info)
 
       expect(signozAdapter.url.toString()).toBe("https://signoz.example.com:4318/v1/logs")
-      expect(AxiosApiClient).toHaveBeenCalledWith({
-        baseUrl: "https://signoz.example.com:4318/v1/logs",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
     })
 
     it("should accept a custom route endpoint", () => {
       signozAdapter = new SignozAdapter("http://localhost:8082/custom/endpoint", Severity.Warn)
 
       expect(signozAdapter.url.toString()).toBe("http://localhost:8082/custom/endpoint")
-      expect(AxiosApiClient).toHaveBeenCalledWith({
-        baseUrl: "http://localhost:8082/custom/endpoint",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
     })
 
     it("should default to Severity.Debug if minimumLogLevel is not provided", () => {
@@ -81,7 +61,7 @@ describe("SignozAdapter Tests", () => {
 
       await signozAdapter.trace("Trace message")
 
-      expect(mockApiClient.post).not.toHaveBeenCalled()
+      expect(global.fetch).not.toHaveBeenCalled()
     })
 
     it("should log info when minimumLogLevel is Info", async () => {
@@ -89,7 +69,7 @@ describe("SignozAdapter Tests", () => {
 
       await signozAdapter.info("Info message")
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", expect.any(Object))
+      expect(global.fetch).toHaveBeenCalled()
     })
 
     it("should not log debug when minimumLogLevel is Info", async () => {
@@ -97,7 +77,7 @@ describe("SignozAdapter Tests", () => {
 
       await signozAdapter.debug("Debug message")
 
-      expect(mockApiClient.post).not.toHaveBeenCalled()
+      expect(global.fetch).not.toHaveBeenCalled()
     })
 
     it("should log error when minimumLogLevel is Warn", async () => {
@@ -105,7 +85,7 @@ describe("SignozAdapter Tests", () => {
 
       await signozAdapter.error("Error message")
 
-      expect(mockApiClient.post).toHaveBeenCalled()
+      expect(global.fetch).toHaveBeenCalled()
     })
   })
 
@@ -117,7 +97,8 @@ describe("SignozAdapter Tests", () => {
     it("should post trace logs to the provided URL", async () => {
       await signozAdapter.trace("Trace message")
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(global.fetch).toHaveBeenCalledWith("http://collector:4318/v1/logs", expect.objectContaining({ method: "POST" }))
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -138,7 +119,7 @@ describe("SignozAdapter Tests", () => {
     it("should post debug logs to the provided URL", async () => {
       await signozAdapter.debug("Debug message")
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -159,7 +140,7 @@ describe("SignozAdapter Tests", () => {
     it("should post info logs to the provided URL", async () => {
       await signozAdapter.info("Info message")
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -180,7 +161,7 @@ describe("SignozAdapter Tests", () => {
     it("should post warn logs to the provided URL", async () => {
       await signozAdapter.warn("Warn message")
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -201,7 +182,7 @@ describe("SignozAdapter Tests", () => {
     it("should post error logs to the provided URL", async () => {
       await signozAdapter.error("Error message")
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -224,7 +205,7 @@ describe("SignozAdapter Tests", () => {
       error.stack = "Error: Test error\n    at test.js:1:1"
       await signozAdapter.exception("Exception message", error)
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -276,7 +257,7 @@ describe("SignozAdapter Tests", () => {
 
       await signozAdapter.info("Test message", options)
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             resource: {
@@ -315,8 +296,7 @@ describe("SignozAdapter Tests", () => {
         },
       })
 
-      const callArgs = mockApiClient.post.mock.calls[0]
-      const payload = callArgs[1]
+      const payload = lastFetchBody()
       expect(payload.resourceLogs[0]).not.toHaveProperty("resource")
       expect(payload.resourceLogs[0]).toHaveProperty("scopeLogs")
     })
@@ -332,7 +312,7 @@ describe("SignozAdapter Tests", () => {
         extraData: { nullValue: null },
       })
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -359,7 +339,7 @@ describe("SignozAdapter Tests", () => {
         extraData: { undefinedValue: undefined },
       })
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -394,7 +374,7 @@ describe("SignozAdapter Tests", () => {
 
       await signozAdapter.info("Test message", { exception: error })
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -427,7 +407,7 @@ describe("SignozAdapter Tests", () => {
     it("should include exception as string when exception is a string", async () => {
       await signozAdapter.info("Test message", { exception: "String error" as any })
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -452,7 +432,7 @@ describe("SignozAdapter Tests", () => {
     it("should flatten exception object when exception is an object", async () => {
       await signozAdapter.info("Test message", { exception: { code: 500, type: "server" } as any })
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -484,7 +464,7 @@ describe("SignozAdapter Tests", () => {
 
       await signozAdapter.info("Test message", { exception: error })
 
-      expect(mockApiClient.post).toHaveBeenCalledWith("", {
+      expect(lastFetchBody()).toEqual({
         resourceLogs: [
           {
             scopeLogs: [
@@ -505,8 +485,7 @@ describe("SignozAdapter Tests", () => {
         ],
       })
 
-      const callArgs = mockApiClient.post.mock.calls[0]
-      const payload = callArgs[1]
+      const payload = lastFetchBody()
       const attributes = payload.resourceLogs[0].scopeLogs[0].logRecords[0].attributes
       expect(attributes.find((attr: any) => attr.key === "exception_stack")).toBeUndefined()
     })
@@ -523,11 +502,7 @@ describe("SignozAdapter Tests", () => {
     })
 
     it("should log error when API call fails", async () => {
-      mockApiClient.post.mockResolvedValue({
-        success: false,
-        message: "API Error",
-        data: "Error details",
-      })
+      mockFetchError("API Error", "Error details")
 
       const result = await (signozAdapter as any).captureMessage("Test", SignozSeverity.Info)
 
@@ -536,11 +511,7 @@ describe("SignozAdapter Tests", () => {
     })
 
     it("should return true when API call succeeds", async () => {
-      mockApiClient.post.mockResolvedValue({
-        success: true,
-        message: "Success",
-        data: {},
-      })
+      mockFetchOk()
 
       const result = await (signozAdapter as any).captureMessage("Test", SignozSeverity.Info)
 

--- a/package.json
+++ b/package.json
@@ -51,10 +51,9 @@
     "@semantic-release/git": "^10.0.1"
   },
   "dependencies": {
-    "@akadenia/api": "^1.2.1",
     "@sentry/types": "^10.46.0"
   },
   "engines": {
-    "node": ">=20.x"
+    "node": ">=24.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "@sentry/types": "^10.46.0"
   },
   "engines": {
-    "node": ">=24.x"
+    "node": ">=20.x"
   }
 }

--- a/src/adapters/sentry_adapter.ts
+++ b/src/adapters/sentry_adapter.ts
@@ -1,6 +1,5 @@
-import { Severity, ILogger, Options } from "../logger"
+import { Severity, ILogger, Options, ApiResponse } from "../logger"
 import { Client, Scope, SeverityLevel } from "@sentry/types"
-import { AkadeniaApiResponse } from "@akadenia/api"
 
 export enum SentrySeverity {
   Debug = "debug",
@@ -26,7 +25,7 @@ export class SentryAdapter implements ILogger {
     this.minimumLogLevel = minimumLogLevel
   }
 
-  private trimResponse(response: AkadeniaApiResponse): any {
+  private trimResponse(response: ApiResponse): any {
     // Trim response to only essential fields: status, statusText, message, data
     const trimmedResponse: any = {}
     if (response && typeof response === "object") {
@@ -39,7 +38,7 @@ export class SentryAdapter implements ILogger {
     return trimmedResponse
   }
 
-  private processData(extraData: any, response?: AkadeniaApiResponse): any {
+  private processData(extraData: any, response?: ApiResponse): any {
     // Accommodate extraData first (Sentry has 16kb limit)
     const processedData: any = { ...(extraData || {}) }
 

--- a/src/adapters/signoz_adapter.ts
+++ b/src/adapters/signoz_adapter.ts
@@ -1,5 +1,4 @@
 import { Severity, ILogger, Options } from "../logger"
-import { AxiosApiClient } from "@akadenia/api"
 
 export enum SignozSeverity {
   Warn = "warn",
@@ -51,19 +50,9 @@ export class SignozAdapter implements ILogger {
 
   minimumLogLevel: Severity
 
-  api: AxiosApiClient
-
   constructor(url: string | URL, minimumLogLevel = Severity.Debug) {
     this.minimumLogLevel = minimumLogLevel
-
     this.url = typeof url === "string" ? new URL(url) : url
-
-    this.api = new AxiosApiClient({
-      baseUrl: this.url.toString(),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    })
   }
 
   private convertAttributesToOTLP(
@@ -156,10 +145,15 @@ export class SignozAdapter implements ILogger {
       resourceLogs: [resourceLog],
     }
 
-    const apiResponse = await this.api.post("", payload)
-    if (!apiResponse.success) {
-      console.debug(`${apiResponse.message}: ${apiResponse.data}`)
+    const response = await fetch(this.url.toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    })
 
+    if (!response.ok) {
+      const text = await response.text().catch(() => "")
+      console.debug(`${response.statusText}: ${text}`)
       return false
     }
 

--- a/src/adapters/signoz_adapter.ts
+++ b/src/adapters/signoz_adapter.ts
@@ -145,19 +145,35 @@ export class SignozAdapter implements ILogger {
       resourceLogs: [resourceLog],
     }
 
-    const response = await fetch(this.url.toString(), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    })
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 5000)
 
-    if (!response.ok) {
-      const text = await response.text().catch(() => "")
-      console.debug(`${response.statusText}: ${text}`)
+    try {
+      const response = await fetch(this.url.toString(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      })
+
+      clearTimeout(timeoutId)
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "")
+        console.debug(`${response.statusText}: ${text}`)
+        return false
+      }
+
+      return true
+    } catch (err) {
+      clearTimeout(timeoutId)
+      if (err instanceof Error && err.name === "AbortError") {
+        console.debug("SignozAdapter fetch timeout")
+        return false
+      }
+      console.debug("SignozAdapter fetch error:", err)
       return false
     }
-
-    return true
   }
 
   async trace(message: string, options?: Options | undefined) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,3 @@
-import { AkadeniaApiResponse } from "@akadenia/api"
 import { createDetailedObjectSummary } from "./serialization"
 
 export enum Severity {
@@ -9,10 +8,17 @@ export enum Severity {
   Error,
 }
 
+export type ApiResponse = {
+  status?: number
+  statusText?: string
+  message?: string
+  data?: any
+}
+
 export type Options = {
   forceConsole?: boolean
   extraData?: any
-  response?: AkadeniaApiResponse
+  response?: ApiResponse
   exception?: Error
   signozPayload?: any
 }


### PR DESCRIPTION
Removes the @akadenia/api dependency to eliminate the transitive axios 1.15.0 vulnerability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an external API dependency.
* **Refactor**
  * Adapters updated to send logs via direct HTTP fetch with improved response/error handling, timeouts, and payload trimming.
  * Logger made self-contained with an internal response shape.
* **Bug Fixes**
  * Better handling of failed submissions, timeouts, and clearer debug logging on errors.
* **Tests**
  * Tests updated to mock and validate network fetch calls and captured payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->