### PR TITLE
chore(ci): align ci and scripts with api repo standards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,11 +62,19 @@ jobs:
                 -d "$PAYLOAD")
               HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
               BODY=$(echo "$RESPONSE" | head -n -1)
-              if [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "422" ]; then
+              if [ "$HTTP_CODE" = "201" ]; then
+                echo "Release PR created successfully."
+              elif [ "$HTTP_CODE" = "422" ]; then
+                if echo "$BODY" | grep -qi "pull request already exists"; then
+                  echo "Release PR already exists — skipping."
+                else
+                  echo "PR creation failed with unexpected 422: $BODY"
+                  exit 1
+                fi
+              else
                 echo "PR creation failed (HTTP $HTTP_CODE): $BODY"
                 exit 1
               fi
-              echo "PR creation response (HTTP $HTTP_CODE): $BODY"
             fi
 
 workflows:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ Examples:
 Before every push, run all three and fix any failures:
 
 ```bash
-npm run lint
-npm test
-npm run build
+pnpm run lint
+pnpm test
+pnpm run build
 ```
 
 Never use `--no-verify`. No exceptions.
@@ -62,7 +62,7 @@ Do not manually bump versions in `package.json`.
 ## TypeScript
 
 - Keep TypeScript at `^5.x` — **do not upgrade to TypeScript 6.x** until `ts-jest` adds support
-- Build with `npm run build` (compiles to `dist/`)
+- Build with `pnpm run build` (compiles to `dist/`)
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "version": "git add -A src",
     "updateLink": "pnpm build && pnpm rm -g @akadenia/logger && pnpm add -g ."
   },
-  "packageManager": "pnpm@11.1.3",
+  "packageManager": "pnpm@11.9.0",
   "files": [
     "dist"
   ],
@@ -55,6 +55,7 @@
     "@sentry/types": "^10.46.0"
   },
   "engines": {
-    "node": ">=22.x"
+    "node": ">=22.x",
+    "pnpm": ">=11.x"
   }
 }

--- a/scripts/commit-release-assets.sh
+++ b/scripts/commit-release-assets.sh
@@ -25,7 +25,7 @@ git config user.email 'auto@akadenia.com'
 git checkout -b $BRANCH_NAME
 
 # Commit changes
-git add package.json package-lock.json CHANGELOG.md
+git add package.json pnpm-lock.yaml CHANGELOG.md
 git commit -m "chore(release): add release assets from $VERSION"
 
 # Push branch to the remote


### PR DESCRIPTION
Aligns AkadeniaLogger CI and scripts with the standards being rolled out across public packages:

- Add `engines.pnpm` and bump `packageManager` to `pnpm@11.9.0`
- Fix release-assets script to stage `pnpm-lock.yaml` instead of `package-lock.json`
- Fix CircleCI release job to validate 422 body (only accept "pull request already exists")
- Update AGENTS.md pre-push commands to reference `pnpm`