### PR TITLE
fix: unify CI scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
                 --arg body "Merge release ${VERSION} assets" \
                 '{title: $title, head: $head, base: $base, body: $body}')
               RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
                 -H "Accept: application/vnd.github+json" \
                 "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls" \
                 -d "$PAYLOAD")


### PR DESCRIPTION
## Summary
- Use consistent test command (pnpm test) for all packages instead of conditional
- Use GH_TOKEN consistently for GitHub API access (was using GITHUB_TOKEN)
- AkadeniaAzureStorage retains test:with-azurite for Azure Blob Storage testing

## Test plan
- [ ] CI workflows execute successfully on all packages
- [ ] Release job creates PRs with correct token